### PR TITLE
added nbformat to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ django
 djangorestframework
 django-cors-headers
 django-datetimepicker
+nbformat


### PR DESCRIPTION
without nbformat in dependencies we face the belowing problem while running

from nbformat import ValidationError
ModuleNotFoundError: No module named 'nbformat'